### PR TITLE
CrateTrips cannot be initialized without a recipient

### DIFF
--- a/src/interfaces/crate-repository.js
+++ b/src/interfaces/crate-repository.js
@@ -7,7 +7,7 @@
 * @property {Function} getCrateById - finds a crate in the data store by uuid
 * @property {Function} getAllCrates - finds all crates in the data store
 * @property {Function} getCrateTripsByCrateId - finds a list of all unique trips of a specified crate
-* @property {Function} getCratesByUserId - finds all crates associated with a specified user
+* @property {Function} getCratesByRecipientId - finds all crates associated with a specified recipient
 * @property {Function} markCrateReturned -  set a crate's status to indicate a pending return
 * @property {Function} delete - deletes a crate in the data store by its uuid
 * @property {Function} setCrateRecipient - associates a crate with a recipient user in the data store
@@ -54,9 +54,9 @@ function ICrateRepository(myImpl) {
 
     /**
     @param {User} user - an instance of User
-    @returns {Array} - a list of crates associated with a specified user
+    @returns {Array} - a list of crates associated with a specified recipient
     */
-    this.getCratesByUserId = myImpl.getCratesByUserId || required;
+    this.getCratesByRecipientId = myImpl.getCratesByRecipientId || required;
 
     /**
     @param {CrateDTO} crate - an instance of CrateDTO

--- a/src/lib/database/connectors/template.js
+++ b/src/lib/database/connectors/template.js
@@ -61,7 +61,7 @@ module.exports = {
             "size": ["L"],
             "tripId": "172b101d-3d24-4172-8e9d-2c34beb9c07f",
             "merchantId": "e3634bd2-7cb4-45b7-a442-f38ee4ad008b",
-            "userId": "b0a2ca71-475d-4a4e-8f5b-5a4ed9496a09",
+            "recipientId": "b0a2ca71-475d-4a4e-8f5b-5a4ed9496a09",
             "createdDate": "2021-02-24T19:04:33.436344",
             "lastModified": "2021-01-24T17:45:36.230152",
             "lastPing": "2021-02-24T19:04:33.436344",

--- a/src/lib/repository/crate/dto.js
+++ b/src/lib/repository/crate/dto.js
@@ -33,6 +33,7 @@ const defaultTelemetry = {
  * @property {String} id 
  * @property {String} status
  * @property {String} size
+ * @property {String} recipientId
  * @property {String} merchantId
  * @property {String} lastPing
  * @property {String} telemetry
@@ -45,6 +46,7 @@ const defaultTelemetry = {
   * @param {String} status - status of crate
   * @param {String} size - size of crate
   * @param {String} tripId - uuid for a unique crate trip
+  * @param {String} recipientId - uuid for a recipient associated with a specified crate
   * @param {String} merchantId - uuid for a merchant associated with a specified crate
   * @param {String} lastPing - last ping received from a specified crate
   * @param {Object} telemetry - summary of telemetry data 
@@ -53,7 +55,7 @@ const defaultTelemetry = {
   * @returns {CrateDTO}
   */
 
-function CrateDTO({id, size, status=["awaitingDeployment"], tripId=null, merchantId=null, userId=null, lastPing=null, telemetry, createdDate=new Date().toISOString(), lastModified=null }) {
+function CrateDTO({id, size, status=["awaitingDeployment"], tripId=null, merchantId=null, recipientId=null, lastPing=null, telemetry, createdDate=new Date().toISOString(), lastModified=null }) {
     
     const crateData = {
       id,
@@ -61,7 +63,7 @@ function CrateDTO({id, size, status=["awaitingDeployment"], tripId=null, merchan
       size, 
       tripId, 
       merchantId,
-      userId,
+      recipientId,
       lastPing,
       telemetry: telemetry || defaultTelemetry,
       createdDate, 

--- a/src/lib/repository/crate/index.js
+++ b/src/lib/repository/crate/index.js
@@ -78,9 +78,9 @@ function CrateRepository(databaseConnector) {
     }
 
 
-    this.getCratesByUserId = async function(id) {
+    this.getCratesByRecipientId = async function(id) {
         const crates = await databaseConnector.findAll("crates");
-        return crates.filter(crate => crate.userId === id);
+        return crates.filter(crate => crate.recipientId === id);
     }
 
 

--- a/src/schemas/crate.json
+++ b/src/schemas/crate.json
@@ -10,7 +10,7 @@
             "id": "2055c145-7d3e-446c-a7ad-ae6aaf886335",
             "size": ["L"],
             "tripId": "172b101d-3d24-4172-8e9d-2c34beb9c07f",
-            "userId": "b0a2ca71-475d-4a4e-8f5b-5a4ed9496a09",
+            "recipientId": "b0a2ca71-475d-4a4e-8f5b-5a4ed9496a09",
             "merchantId": "e3634bd2-7cb4-45b7-a442-f38ee4ad008b",
             "createdDate": "2021-02-24T19:04:33.436344",
             "lastModified": "2021-01-24T17:45:36.230152",
@@ -110,10 +110,10 @@
                 "e3634bd2-7cb4-45b7-a442-f38ee4ad008b"
             ]
         },
-        "userId": {
-            "$id": "#/properties/userId",
+        "recipientId": {
+            "$id": "#/properties/recipientId",
             "type": ["string", "null"],
-            "title": "The userId schema",
+            "title": "The recipientId schema",
             "description": "The uuid of the user associated with this crate.",
             "default": "",
             "examples": [

--- a/src/services/crate.js
+++ b/src/services/crate.js
@@ -47,12 +47,12 @@ function Crate(repo, crateDTO) {
 
     /**
     Associates the crate with a recipient user in the data store.
-    @param {String} userId - a uuid for the recipient user
+    @param {String} recipientId - a uuid for the recipient user
     */
-    this.setRecipient = async function(userId) {
-        const crateDTO = new CrateDTO(Object.assign(this._data, userId));
+    this.setRecipient = async function(recipientId) {
+        const crateDTO = new CrateDTO(Object.assign(this._data, recipientId));
         const crate = await this._repo.crate.setCrateRecipient(crateDTO);
-        this._data.userId = userId;
+        this._data.recipientId = recipientId;
     }
 
     /**
@@ -97,8 +97,13 @@ function Crate(repo, crateDTO) {
     */
     this.startTrip = async function({originAddress, destinationAddress, trackingNumber}) {
         if (!this._data.merchantId) {
-            throw new Error("CrateError.CannotStartTrip => Cannot start crate trip without merchantId assigned to associated crate");
+            throw new Error("CrateError.CannotStartTrip.missingMerchantId => Cannot start crate trip without merchantId assigned to associated crate");
         }
+
+        if (!this._data.recipientId) {
+            throw new Error("CrateError.CannotStartTrip.missingRecipientId => Cannot start crate trip without recipientId assigned to associated crate")
+        }
+
         const id = uuid.v4();
         const status = ["inTransit"];
         const crateTripDTO = new CrateTripDTO({
@@ -225,8 +230,8 @@ function CrateService({crateRepo, crateTripRepo}) {
     /**
      * @param {User} user - an instance of a User
     */
-    this.getCratesByUser = async function(user) {
-        const crateList = await this._repo.crate.getCratesByUserId(user.id);
+    this.getCratesByRecipient = async function(user) {
+        const crateList = await this._repo.crate.getCratesByRecipientId(user.id);
         return crateList.map((c) => new Crate(this._repo.crate, new CrateDTO(c)));
     }
 

--- a/tests/unit/crate-service.test.js
+++ b/tests/unit/crate-service.test.js
@@ -107,7 +107,7 @@ test("Should associate a specified user with a crate", async() => {
     await testCrate.save();
     await testCrate.setRecipient(thorUserId);
   
-    expect(testCrate._data.userId === thorUserId).toBe(true);
+    expect(testCrate._data.recipientId === thorUserId).toBe(true);
 });
 
 
@@ -120,10 +120,12 @@ test("Should get a list of crates associated with a specified user", async() => 
     await testCrate.save();
     await testCrate.setRecipient(thorUserId);
   
-    const crateList = await testCrateService.getCratesByUser({ id: thorUserId });
+    const crateList = await testCrateService.getCratesByRecipient({ 
+        id: thorUserId 
+    });
 
     expect(Array.isArray(crateList)).toBe(true);
-    expect(crateList[0]._data.userId === thorUserId).toBe(true);
+    expect(crateList[0]._data.recipientId === thorUserId).toBe(true);
 });
 
 
@@ -179,7 +181,8 @@ test("Should create a new trip for an existing crate", async() => {
     };
     const testCrate = await testCrateService.createCrate({
       size: ["S"],
-      merchantId: faker.random.uuid()
+      merchantId: faker.random.uuid(),
+      recipientId: faker.random.uuid()
     });
     
     const testCrateId = await testCrate.save();
@@ -200,7 +203,8 @@ test("Should create a new trip for an existing crate", async() => {
 test("Should push telemetry data to platform", async() => {
     const testCrate = await testCrateService.createCrate({
       size: ["S"],
-      merchantId: faker.random.uuid()
+      merchantId: faker.random.uuid(),
+      recipientId: faker.random.uuid()
     });
     const originAddress = {
         street: faker.address.streetName(),
@@ -301,7 +305,8 @@ test("Pushing crate telemetry should add a waypoint to the associated CrateTrip"
 
     const testCrate = await testCrateService.createCrate({
       size: ["S"],
-      merchantId: faker.random.uuid()
+      merchantId: faker.random.uuid(),
+      recipientId: faker.random.uuid()
     });
     
     const testCrateId = await testCrate.save();
@@ -349,7 +354,8 @@ test("Should return JSON object representation of a CrateTrip", async() => {
     };
     const testCrate = await testCrateService.createCrate({
       size: ["S"],
-      merchantId: faker.random.uuid()
+      merchantId: faker.random.uuid(),
+      recipientId: faker.random.uuid()
     });
     
     await testCrate.save();
@@ -391,6 +397,37 @@ test("Should throw an error when crateTrip is initialized without a merchantId a
             trackingNumber: faker.random.uuid()       
         });   
     } catch(e) {
-        expect(e.message).toMatch("CrateError.CannotStartTrip");
+        expect(e.message).toMatch("CrateError.CannotStartTrip.missingMerchantId");
+    }
+});
+
+test("Should throw an error when crateTrip is initialized without a recipientId assigned to the associated crate", async() => {
+    const originAddress = {
+        street: faker.address.streetName(),
+        apartmentNumber: "7",
+        city: faker.address.city(),
+        state: faker.address.stateAbbr(),
+        zip: faker.address.zipCode()
+    };
+    const destinationAddress = {
+        street: faker.address.streetName(),
+        city: faker.address.city(),
+        state: faker.address.stateAbbr(),
+        zip: faker.address.zipCode()
+    };
+    const testCrate = await testCrateService.createCrate({
+      size: ["S"],
+      merchantId: faker.random.uuid()
+    });
+    await testCrate.save();
+
+    try {
+        await testCrate.startTrip({
+            originAddress,
+            destinationAddress,
+            trackingNumber: faker.random.uuid()       
+        });   
+    } catch(e) {
+        expect(e.message).toMatch("CrateError.CannotStartTrip.missingRecipientId");
     }
 });


### PR DESCRIPTION
Ensures there is a `recipientId` associated with the `Crate` entity before initializing a `CrateTrip` by calling the `crate.startTrip` method.