### PR TITLE
Trip data is attached to a Crate entity when the entity is fetched from the database.

### DIFF
--- a/src/lib/repository/crate-trip/dto.js
+++ b/src/lib/repository/crate-trip/dto.js
@@ -88,13 +88,13 @@ function CrateTripDTO({id, crateId, departureTimestamp, arrivalTimestamp=null, t
 
 function CrateTelemetryDTO({timestamp, telemetry}) {
     
-    const crateTelemetryData = [{
+    const crateTelemetryData = {
         timestamp,
         telemetry
-    }];
+    };
         
    
-  if(!crateTelemetrySchemaValidation(crateTelemetryData)) {
+  if(!crateTelemetrySchemaValidation([crateTelemetryData])) {
     throw new Error(`CrateTelemetryDTOError/InvalidCrateTelemetryDTO => ${JSON.stringify(crateTelemetrySchemaValidation.errors, null, 2)}`);
   }
 

--- a/tests/unit/crate-service.test.js
+++ b/tests/unit/crate-service.test.js
@@ -328,6 +328,67 @@ test("Pushing crate telemetry should add a waypoint to the associated CrateTrip"
 });
 
 
+test("Current trip data should be available on Crates retrieved from the database", async() => {
+    const originAddress = {
+        street: faker.address.streetName(),
+        apartmentNumber: "7",
+        city: faker.address.city(),
+        state: faker.address.stateAbbr(),
+        zip: faker.address.zipCode()
+    };
+    const destinationAddress = {
+        street: faker.address.streetName(),
+        city: faker.address.city(),
+        state: faker.address.stateAbbr(),
+        zip: faker.address.zipCode()
+    };
+
+    const fakeTelemetryData = {
+        "temp": {
+            "degreesFahrenheit": String(faker.random.float())
+        },
+        "location": {
+            "coords": {
+                "lat": faker.address.latitude(),
+                "long": faker.address.longitude()
+            },
+            "zip": faker.address.zipCode()
+        },
+        "sensors": {
+            "moisture": {
+                "thresholdExceeded": false
+            },
+            "thermometer": {
+                "thresholdExceeded": false
+            },
+            "photometer": {
+                "thresholdExceeded": false
+            }
+        }
+    };
+
+    const testCrate = await testCrateService.createCrate({
+      size: ["S"],
+      merchantId: faker.random.uuid(),
+      recipientId: faker.random.uuid()
+    });
+    
+    const testCrateId = await testCrate.save();
+    const testCrateTripId = await testCrate.startTrip({
+        originAddress, 
+        destinationAddress, 
+        trackingNumber: faker.random.uuid()
+    });
+
+    await testCrate.pushTelemetry(fakeTelemetryData);
+    expect(testCrate.currentTrip.waypoints.length === 1).toBe(true);
+
+    const returnedTestCrate = await testCrateService.getCrateById(testCrateId);
+    expect(returnedTestCrate.currentTrip.waypoints.length === 1).toBe(true);
+});
+
+
+
 test("Should return JSON object representation of a Crate", async() => {
     const testCrate = await testCrateService.createCrate({
       size: ["S"]


### PR DESCRIPTION
`Crate` entities returned from the database by the `getCrateById` method _only_, will have the associated `CrateTrip` attached at `crate.currentTrip`.